### PR TITLE
Modified autoloader to only load Azure AD B2C classes and dependencies

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -2,8 +2,15 @@
 
 /** 
  * Parses the class name and requires the correct file.
+ *
+ *  @param $class
  */
 function autoload($class) {
+	// only try to autoload AD B2C classes or their vendor dependencies
+	if ( 0 !== strpos( $class, 'B2C' ) && 0 !== strpos( $class, 'Crypt' ) && 0 !== strpos ( $class, 'Math' ) ) {
+		return;
+	}
+
 	if (strpos($class, 'Crypt_') === false && strpos($class, 'Math_') === false) {
 		$class_filename = 'class-' . strtolower(str_replace('_', '-', $class)) . '.php';
 	} else if (strpos($class, 'Math_') === false) {
@@ -11,7 +18,12 @@ function autoload($class) {
 	} else {
 		$class_filename = 'phpseclib/Math/' . str_replace('Math_', '', $class) . '.php';
 	}
-	require_once $class_filename;
+
+	$plugin_directory = plugin_dir_path( __FILE__ );
+
+	if ( file_exists( $plugin_directory.$class_filename ) ) {
+		require_once $class_filename;
+	}
 }
 
 /**


### PR DESCRIPTION
This fixes an issue with the plugin causing Wordpress sites to throw fatal errors when other plugins, themes, and standard Wordpress code also use the spl_autoload_register function.