### PR TITLE
Enhancements to enable Global Admins access to WordPress administrator role

### DIFF
--- a/AuthorizationHelperForGraph.php
+++ b/AuthorizationHelperForGraph.php
@@ -1,0 +1,45 @@
+<?php
+//Helper file updated to pull configuration settings from WordPress.
+//Original sourced from https://github.com/Azure-Samples/active-directory-php-graphapi-web/commit/6da6cd2f8ab14976aa4243d28fa7517d99176297
+// A class that provides authortization token for apps that need to access Azure Active Directory Graph Service.
+class AuthorizationHelperForAADGraphService
+{
+    // Post the token generated from the symettric key and other information to STS URL and construct the authentication header
+    public static function getAuthenticationHeader($appTenantDomainName, $appPrincipalId, $password){
+        // Password
+        $clientSecret = urlencode(B2C_settings::$clientSecret);
+        // Information about the resource we need access for which in this case is graph.
+        $graphId = 'https://graph.windows.net';
+        $protectedResourceHostName = 'graph.windows.net';
+        $graphPrincipalId = urlencode($graphId);
+        // Information about the app
+        $clientPrincipalId = urlencode($appPrincipalId);
+        
+        // Construct the body for the STS request
+        $authenticationRequestBody = 'grant_type=client_credentials&client_secret='.$clientSecret
+                  .'&'.'resource='.$graphPrincipalId.'&'.'client_id='.$clientPrincipalId;
+        
+        //Using curl to post the information to STS and get back the authentication response    
+        $ch = curl_init();
+        // set url 
+        $stsUrl = 'https://login.windows.net/'.$appTenantDomainName.'/oauth2/token?api-version=1.0';        
+        curl_setopt($ch, CURLOPT_URL, $stsUrl); 
+        // Get the response back as a string 
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
+        // Mark as Post request
+        curl_setopt($ch, CURLOPT_POST, 1);
+        // Set the parameters for the request
+        curl_setopt($ch, CURLOPT_POSTFIELDS,  $authenticationRequestBody);
+        
+        // By default, HTTPS does not work with curl.
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        // read the output from the post request
+        $output = curl_exec($ch);         
+        // close curl resource to free up system resources
+        curl_close($ch);      
+        // decode the response from sts using json decoder
+        $tokenOutput = json_decode($output);
+        return 'Authorization:' . $tokenOutput->{'token_type'}.' '.$tokenOutput->{'access_token'};
+    }
+}
+?>

--- a/GraphServiceAccessHelper.php
+++ b/GraphServiceAccessHelper.php
@@ -1,0 +1,232 @@
+<?php
+    //Helper file updated to pull configuration settings from WordPress.
+    //Original sourced from https://github.com/Azure-Samples/active-directory-php-graphapi-web/commit/6da6cd2f8ab14976aa4243d28fa7517d99176297
+    //Require other files.
+    require_once 'AuthorizationHelperForGraph.php';   
+    class GraphServiceAccessHelper
+    {
+        // Constructs a Http GET request to a feed passed in as paremeter.
+        // Returns the json decoded respone as the objects that were recieved in feed.
+        public static function getFeed($feedName){
+            // initiaze curl which is used to make the http request.
+            $ch = curl_init();
+            // Add authorization and other headers. Also set some common settings.
+            self::AddRequiredHeadersAndSettings($ch);
+            // set url 
+            $feedURL = "https://graph.windows.net/".B2C_Settings::$tenant."/".$feedName;
+            $feedURL = $feedURL."?".B2C_Settings::$api_version;
+            curl_setopt($ch, CURLOPT_URL, $feedURL);
+            //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            // $output contains the output string
+            $output = curl_exec($ch);
+            // close curl resource to free up system resources 
+            curl_close($ch);      
+            $jsonOutput = json_decode($output);
+            // There is a field for odata metadata that we ignore and just consume the value
+            return $jsonOutput->{'value'};
+        }
+        // Constructs a Http GET request to a linked feed based on the source entry and navigation property name.        
+        public static function getLinkedFeed($sourceFeedName, $sourceEntryId, $navigationPropertyName){
+            //initiaze curl which is used to make the http request
+            $ch = curl_init();
+            // Add authorization and other headers. Also set some common settings.
+            self::AddRequiredHeadersAndSettings($ch);
+            // create URL to the linked feed by using the navigation property name and the key value for the source entry.
+            $feedURL = "https://graph.windows.net/".B2C_Settings::$tenant."/".$sourceFeedName .'(\''. $sourceEntryId . '\')' .'/'.$navigationPropertyName;
+            $feedURL = $feedURL."?".B2C_Settings::$api_version;
+            curl_setopt($ch, CURLOPT_URL, $feedURL);
+            //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            // $output contains the output string 
+            $output = curl_exec($ch);
+            // close curl resource to free up system resources 
+            curl_close($ch);      
+            $jsonOutput = json_decode($output);
+            // There is a field for odata metadata that we ignore and just consume the value
+            return $jsonOutput->{'value'};
+        }
+        // Constructs a Http GET request to a feed passed in as paremeter and uses the field information as the filter clause.
+        // Returns the json decoded respone as the objects that were recieved in feed.        
+        public static function getFeedWithFilterClause($feedName, $fieldName, $fieldValue){
+            //initiaze curl which is used to make the http request
+            $ch = curl_init();
+            // Add authorization and other headers. Also set some common settings.
+            self::AddRequiredHeadersAndSettings($ch);
+            // set url based on the filter clause. This uses the standard OData syntax to create the filter clause.
+            $feedURL = "https://graph.windows.net/".B2C_Settings::$tenant."/".$feedName .'?$filter='.$fieldName.urlencode(' eq ')
+                       .'(\''.urlencode($fieldValue).'\')';
+            $feedURL = $feedURL."&api-version=2013-04-05";
+            curl_setopt($ch, CURLOPT_URL, $feedURL);
+            //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            // $output contains the output string 
+            $output = curl_exec($ch);
+            // close curl resource to free up system resources 
+            curl_close($ch);      
+            $jsonOutput = json_decode($output);
+            // There is a field for odata metadata that we ignore and just consume the value
+            return $jsonOutput->{'value'};
+        }
+        // Constructs a Http GET request to fetch an entry based on the feed name and the key value passed in.
+        // Returns the json decoded respone as the objects that were recieved in feed.
+        public static function getEntry($feedName, $keyValue){
+            // initiaze curl which is used to make the http request
+            $ch = curl_init();
+            // Add authorization and other headers. Also set some common settings.
+            self::AddRequiredHeadersAndSettings($ch);
+            // Create url for the entry based on the feedname and the key value
+            $feedURL = 'https://graph.windows.net/'.B2C_Settings::$tenant.'/'.$feedName.'(\''. $keyValue .'\')';
+            $feedURL = $feedURL."?".B2C_Settings::$api_version;
+            curl_setopt($ch, CURLOPT_URL, $feedURL);             
+            //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            // $output contains the output string 
+            $output = curl_exec($ch);
+            // close curl resource to free up system resources 
+            curl_close($ch);      
+            $jsonOutput = json_decode($output);
+            return $jsonOutput;
+        }
+        // Constructs a HTTP POST request for creating and adding an entry 
+        // to a feed based on the feed name and data passed in.
+        public static function addEntryToFeed($feedName, $entry){
+            //initiaze curl which is used to make the http request
+            $ch = curl_init();
+            // Add authorization and other headers. Also set some common settings.
+            self::AddRequiredHeadersAndSettings($ch);
+            // set url
+            $feedURL = "https://graph.windows.net/".B2C_Settings::$tenant.'/'.$feedName;
+            $feedURL = $feedURL."?".B2C_Settings::$api_version;
+            curl_setopt($ch, CURLOPT_URL, $feedURL);
+            // Mark as Post request
+            curl_setopt($ch, CURLOPT_POST, 1);            
+            $data = json_encode($entry);
+            // Set the data for the post request
+            curl_setopt($ch, CURLOPT_POSTFIELDS,  $data);
+            //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            // read the output from the post request
+            $output = curl_exec($ch);
+            // close curl resource to free up system resources
+            curl_close($ch);      
+            // decode the response json decoder
+            $createdEntry = json_decode($output);
+            return $createdEntry;
+        }
+        // Constructs a HTTP POST request for creating and adding a link
+        // between two existing entries using the source and target URLs and the navigation property name.
+        public static function addLinkForEntries($sourceEntryUrl, $targetEntryUrl, $navigationPropertyName){
+            //initiaze curl which is used to make the http request
+            $ch = curl_init();
+            // Add authorization and other headers. Also set some common settings.
+            self::AddRequiredHeadersAndSettings($ch);
+            // set url
+            $feedURL = 'https://graph.windows.net/'.B2C_Settings::$tenant.'/'.$sourceEntryUrl.'/$links/'.$navigationPropertyName;
+            $feedURL = $feedURL."?".B2C_Settings::$api_version;
+            curl_setopt($ch, CURLOPT_URL, $feedURL);
+            // Mark as Post request
+            curl_setopt($ch, CURLOPT_POST, 1);
+            $data = json_encode($targetEntryUrl);
+            // Set the data for the post request
+            curl_setopt($ch, CURLOPT_POSTFIELDS,  $data);
+            //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            
+            // read the output from the post request
+            $output = curl_exec($ch); 
+            // close curl resource to free up system resources
+            curl_close($ch);
+            // decode the response json decoder
+            $createdEntry = json_decode($output);
+            return $createdEntry;
+        }
+        // Constructs a HTTP PATCH request for updating an entry.
+        public static function updateEntry($feedName, $keyValue, $entry){
+            //initiaze curl which is used to make the http request
+            $ch = curl_init();
+            self::AddRequiredHeadersAndSettings($ch);
+            // set url
+            $feedURL = "https://graph.windows.net/".B2C_Settings::$tenant.'/'.$feedName.'(\''. $keyValue .'\')';
+            $feedURL = $feedURL."?".B2C_Settings::$api_version;
+            curl_setopt($ch, CURLOPT_URL, $feedURL); 
+            
+            // Mark as Patch request
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
+                        //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            $data = json_encode($entry);
+            // Set the data for the request
+            curl_setopt($ch, CURLOPT_POSTFIELDS,  $data);
+            // read the output from the request
+            $output = curl_exec($ch); 
+            // close curl resource to free up system resources
+            curl_close($ch);      
+            // decode the response json decoder
+            $udpatedEntry = json_decode($output);
+            return $udpatedEntry;
+        }
+        // Constructs a HTTP DELETE request for deleting an entry.
+        public static function deleteEntry($feedName, $keyValue){
+            //initiaze curl which is used to make the http request
+            $ch = curl_init();
+                        self::AddRequiredHeadersAndSettings($ch);
+            // set url
+            $feedURL = "https://graph.windows.net/".B2C_Settings::$tenant.'/'.$feedName.'(\''. $keyValue .'\')';
+            $feedURL = $feedURL."?".B2C_Settings::$api_version;
+            curl_setopt($ch, CURLOPT_URL, $feedURL); 
+                        //Enable fiddler to capture request
+            //curl_setopt($ch, CURLOPT_PROXY, '127.0.0.1:8888');
+            // Mark as Post request
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+            // read the output from the post request
+            $output = curl_exec($ch); 
+            // close curl resource to free up system resources
+            curl_close($ch);      
+            // decode the response json decoder
+            $deletedEntry = json_decode($output);
+            return $deletedEntry;
+        }
+        // Constructs a Http GET request get changes for the type passed in.
+        // Returns the json decoded respone as the objects that were recieved in feed.
+        public static function getDeltaLinkFeed($feedURL, $feedName){
+            if ($feedName == NULL)
+            {
+                $feedName = "directoryObjects";
+            }
+            // initiaze curl which is used to make the http request.
+            $ch = curl_init();
+            // Add authorization and other headers. Also set some common settings.
+            self::AddRequiredHeadersAndSettings($ch);
+            // set url 
+            if ($feedURL == NULL)
+            {
+                $feedURL = "https://graph.windows.net/".B2C_Settings::$tenant."/".$feedName;
+                $feedURL = $feedURL."?deltaLink=";
+            }
+            // add api-version always to indicate the target version
+            $feedURL = $feedURL."&api-version=2013-04-05";
+            curl_setopt($ch, CURLOPT_URL, $feedURL);
+            // $output contains the output string
+            $output = curl_exec($ch);
+            // close curl resource to free up system resources 
+            curl_close($ch);      
+            $jsonOutput = json_decode($output);
+            // There is a field for odata metadata that we ignore and just consume the value
+            return $jsonOutput;
+        }
+        // Add required headers like authorization header, service version etc.
+        public static function AddRequiredHeadersAndSettings($ch)
+        {
+            //Generate the authentication header
+            $authHeader = AuthorizationHelperForAADGraphService::GetAuthenticationHeader(B2C_Settings::$tenant, B2C_Settings::$graphID, B2C_Settings::$clientSecret);
+            // Add authorization header, request/response format header( for json) and a header to request content for Update and delete operations.  
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array($authHeader,  'Accept:application/json;odata=minimalmetadata',
+                                                        'Content-Type:application/json;odata=minimalmetadata', 'Prefer:return-content'));
+            // Set the option to recieve the response back as string.
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
+            // By default https does not work for CURL.
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
+    }
+?>

--- a/class-b2c-settings-page.php
+++ b/class-b2c-settings-page.php
@@ -121,6 +121,14 @@ class B2C_Settings_Page
             'b2c-settings-page', // Page
             'service_config_section' // Section           
         );     		
+
+        add_settings_field(
+            'b2c_GA_Grant_Admins', // ID
+            'Grant B2C Global Admins Wordpress Administrator Permissions', // Title
+            array( $this, 'b2c_GA_Grant_Admins_callback'), // Callback
+            'b2c-settings-page', // Page
+            'service_config_section' // Section
+        );
     }
 
     /**
@@ -147,6 +155,8 @@ class B2C_Settings_Page
             $new_input['b2c_edit_profile_policy_id'] = sanitize_text_field(strtolower( $input['b2c_edit_profile_policy_id'] ));
 		
         $new_input['b2c_verify_tokens'] = $input['b2c_verify_tokens'];
+
+        $new_input['b2c_GA_Grant_Admins'] = $input['b2c_GA_Grant_Admins'];
 
         return $new_input;
     }
@@ -228,4 +238,17 @@ class B2C_Settings_Page
         
         echo '<input type="checkbox" id="b2c_verify_tokens" name="b2c_config_elements[b2c_verify_tokens]" value="1" class="code" ' . checked( 1, $current_value, false ) . ' />';
     }
+
+    /**
+     * Get the settings option array and print one of its values
+     */
+     public function b2c_GA_Grant_Admins_callback()
+     {
+         if(empty($this->options['b2c_GA_Grant_Admins']))
+            $this->options['b2c_GA_Grant_Admins'] = 0;
+
+            $current_value = $this->options['b2c_GA_Grant_Admins'];
+
+            echo '<input type="checkbox" id="b2c_GA_Grant_Admins" name="b2c_config_elements[b2c_GA_Grant_Admins]" value="1" class="code" ' . checked( 1, $current_value, false ) . ' />';
+     }
 }

--- a/class-b2c-settings-page.php
+++ b/class-b2c-settings-page.php
@@ -124,11 +124,27 @@ class B2C_Settings_Page
 
         add_settings_field(
             'b2c_GA_Grant_Admins', // ID
-            'Grant B2C Global Admins Wordpress Administrator Permissions', // Title
+            'Grant B2C Global Admins Wordpress Administrator Role', // Title
             array( $this, 'b2c_GA_Grant_Admins_callback'), // Callback
             'b2c-settings-page', // Page
             'service_config_section' // Section
         );
+
+		add_settings_field(
+			'b2c_client_secret', // ID
+			'Client Secret', //Title
+			 array( $this, 'b2c_client_secret_callback' ), // Callback
+            'b2c-settings-page', // Page
+            'service_config_section' // Section  
+		);
+
+		add_settings_field(
+			'b2c_graph_id', // ID
+			'Graph API Application ID (Not B2C Application ID)', //Title
+			 array( $this, 'b2c_graph_id_callback' ), // Callback
+            'b2c-settings-page', // Page
+            'service_config_section' // Section  
+		);
     }
 
     /**
@@ -157,6 +173,12 @@ class B2C_Settings_Page
         $new_input['b2c_verify_tokens'] = $input['b2c_verify_tokens'];
 
         $new_input['b2c_GA_Grant_Admins'] = $input['b2c_GA_Grant_Admins'];
+
+		if( isset( $input['b2c_client_secret'] ) )
+            $new_input['b2c_client_secret'] = sanitize_text_field( $input['b2c_client_secret'] );
+
+		if( isset( $input['b2c_graph_id'] ) )
+            $new_input['b2c_graph_id'] = sanitize_text_field( $input['b2c_graph_id'] );
 
         return $new_input;
     }
@@ -251,4 +273,26 @@ class B2C_Settings_Page
 
             echo '<input type="checkbox" id="b2c_GA_Grant_Admins" name="b2c_config_elements[b2c_GA_Grant_Admins]" value="1" class="code" ' . checked( 1, $current_value, false ) . ' />';
      }
+
+     /** 
+     * Get the settings option array and print one of its values
+     */
+    public function b2c_graph_id_callback()
+    {
+        printf(
+            '<input type="text" id="b2c_graph_id" name="b2c_config_elements[b2c_graph_id]" value="%s" />',
+            isset( $this->options['b2c_graph_id'] ) ? esc_attr( $this->options['b2c_graph_id']) : ''
+        );
+    }
+
+	/** 
+     * Get the settings option array and print one of its values
+     */
+    public function b2c_client_secret_callback()
+    {
+        printf(
+            '<input type="password" id="b2c_client_secret" name="b2c_config_elements[b2c_client_secret]" value="%s" />',
+            isset( $this->options['b2c_client_secret'] ) ? esc_attr( $this->options['b2c_client_secret']) : ''
+        );
+    }
 }

--- a/class-b2c-settings.php
+++ b/class-b2c-settings.php
@@ -10,12 +10,16 @@ class B2C_Settings {
 	public static $edit_profile_policy = "";
 	public static $redirect_uri = "";
 	public static $verify_tokens = 1;
+	public static $b2cAdmins = 1;
+	public static $graphID = "";
+	public static $clientSecret = "";
 	
 	// These settings define the authentication flow, but are not configurable on the settings page
 	// because this plugin is made to support OpenID Connect implicit flow with form post responses
 	public static $response_type = "id_token"; 
 	public static $response_mode = "form_post"; 
 	public static $scope = "openid"; 
+	public static $api_version = "api-version=1.6";
 	
 	function __construct() {
 			
@@ -33,6 +37,10 @@ class B2C_Settings {
 			self::$redirect_uri = urlencode(site_url().'/'); 
 			if ($config_elements['b2c_verify_tokens']) self::$verify_tokens = 1;
 			else self::$verify_tokens = 0;
+			if ($config_elements['b2c_GA_Grant_Admins']) self::$b2cAdmins = 1;
+			else self::$b2cAdmins = 0;
+			self::$clientSecret = $config_elements['b2c_client_secret'];
+			self::$graphID = $config_elements['b2c_graph_id'];
 		}
 	}
 


### PR DESCRIPTION
Includes helper files and modified authentication workflow to enable sign in flow automatically granting global admins in B2C access to WordPress as administrators based on setting available to WordPress administrator at time of deployment. 