### PR TITLE
Allows users to save custom fields created in Azure to users in WP

### DIFF
--- a/b2c_authentication.php
+++ b/b2c_authentication.php
@@ -124,6 +124,9 @@ function b2c_verify_token() {
 						);
 
 				$userID = wp_insert_user( $our_userdata ); 
+
+				// Allows custom fields sent over the payload to be saved in Wordpress
+				do_action('b2c_new_userdata', $userID, $token_checker->get_payload());
 			} else if ($policy == B2C_Settings::$edit_profile_policy) { // Update the existing user w/ new attritubtes
 				
 				$first_name = $token_checker->get_claim('given_name');
@@ -137,6 +140,9 @@ function b2c_verify_token() {
 										);
 													
 				$userID = wp_update_user( $our_userdata );
+
+				// Allows custom fields sent over the payload to be updated in Wordpress
+				do_action('b2c_update_userdata', $userID, $token_checker->get_payload());
 			} else {
 				$userID = $user->ID;
 			}

--- a/class-b2c-endpoint-handler.php
+++ b/class-b2c-endpoint-handler.php
@@ -62,7 +62,7 @@ class B2C_Endpoint_Handler {
 											'&redirect_uri='.B2C_Settings::$redirect_uri.
 											'&response_mode='.B2C_Settings::$response_mode.
 											'&scope='.B2C_Settings::$scope;
-		return $authorization_endpoint;
+		return apply_filters('b2c_authorization_endpoint', $authorization_endpoint);
 	}
 	
 	/** 

--- a/class-b2c-token-checker.php
+++ b/class-b2c-token-checker.php
@@ -146,6 +146,13 @@ class B2C_Token_Checker {
 	public function get_claim($name) {
 		return $this->payload[$name];
 	}
+
+	/**
+	 * Returns the payload.
+	 */
+	public function get_payload() {
+		return $this->payload;
+	}
 }
 
 


### PR DESCRIPTION
For example if I want a field called company, I first create the field in Azure, then I add the following code to my Wordpress plugin/functions.php file:

```
function custom_ms_fields($userID, $payload) {
    if (isset($payload['extension_Company']))
        update_user_meta($userID, 'company', sanitize_text_field($payload['extension_Company']));
}
add_action('b2c_new_userdata', 'custom_ms_fields', 10, 2);
add_action('b2c_update_userdata', 'custom_ms_fields', 10, 2);
```
This will save the information the user entered in the company field to the user meta field 'company' in Wordpress
