### PR TITLE
Flow enhancements for password reset, cancel profile edit, and cancel sign-up. Use b2clogin.com instead of login.microsoftonline.com. Improved Wordpress settings page instructions.

### DIFF
--- a/b2c_authentication.php
+++ b/b2c_authentication.php
@@ -129,6 +129,7 @@ function b2c_verify_token() {
 			// Get the userID for the user
 			if ($user == false) { // User doesn't exist yet, create new userID
 				
+				$name = $token_checker->get_claim('name');
 				$first_name = $token_checker->get_claim('given_name');
 				$last_name = $token_checker->get_claim('family_name');
 
@@ -139,7 +140,7 @@ function b2c_verify_token() {
 						'user_registered' => true,
 						'user_status' => 0,
 						'user_email' => $email,
-						'display_name' => $first_name . ' ' . $last_name,
+						'display_name' => $name,
 						'first_name' => $first_name,
 						'last_name' => $last_name
 						);
@@ -147,12 +148,13 @@ function b2c_verify_token() {
 				$userID = wp_insert_user( $our_userdata ); 
 			} else if ($policy == B2C_Settings::$edit_profile_policy) { // Update the existing user w/ new attritubtes
 				
+				$name = $token_checker->get_claim('name');
 				$first_name = $token_checker->get_claim('given_name');
 				$last_name = $token_checker->get_claim('family_name');
 				
 				$our_userdata = array (
 										'ID' => $user->ID,
-										'display_name' => $first_name . ' ' . $last_name,
+										'display_name' => $name,
 										'first_name' => $first_name,
 										'last_name' => $last_name
 										);
@@ -218,7 +220,7 @@ function b2c_edit_profile() {
 function b2c_password_reset() {
 	try {
 		$b2c_endpoint_handler = new B2C_Endpoint_Handler(B2C_Settings::$password_reset_policy);
-		$authorization_endpoint = $b2c_endpoint_handler->get_authorization_endpoint();
+		$authorization_endpoint = $b2c_endpoint_handler->get_authorization_endpoint().'&state=password_reset';
 		wp_redirect($authorization_endpoint);
 	}
 	catch (Exception $e) {
@@ -232,6 +234,14 @@ function b2c_password_reset() {
  * to B2C's authorization endpoint. 
  */
 add_action('wp_authenticate', 'b2c_login');
+
+/** 
+ * Hooks onto the WP lost password action, so user is redirected
+ * to B2C's password reset endpoint. 
+ * 
+ * example.com/wp-login.php?action=lostpassword
+ */
+add_action('login_form_lostpassword', 'b2c_password_reset');
 
 /**
  * Hooks onto the WP page load action, so when user request to edit their profile, 

--- a/class-b2c-settings-page.php
+++ b/class-b2c-settings-page.php
@@ -114,6 +114,14 @@ class B2C_Settings_Page
             'service_config_section' // Section           
         );
 		
+        add_settings_field(
+            'b2c_password_reset_policy_id', // ID
+            'Password Reset Policy', // Title 
+            array( $this, 'b2c_password_reset_policy_id_callback' ), // Callback
+            'b2c-settings-page', // Page
+            'service_config_section' // Section           
+        );
+		
 		add_settings_field(
             'b2c_verify_tokens', // ID
             'Verify ID Tokens', // Title 
@@ -145,6 +153,9 @@ class B2C_Settings_Page
 
         if( isset( $input['b2c_edit_profile_policy_id'] ) )
             $new_input['b2c_edit_profile_policy_id'] = sanitize_text_field(strtolower( $input['b2c_edit_profile_policy_id'] ));
+		
+        if( isset( $input['b2c_password_reset_policy_id'] ) )
+            $new_input['b2c_password_reset_policy_id'] = sanitize_text_field(strtolower( $input['b2c_password_reset_policy_id'] ));
 		
         $new_input['b2c_verify_tokens'] = $input['b2c_verify_tokens'];
 
@@ -188,7 +199,8 @@ class B2C_Settings_Page
     public function b2c_admin_policy_id_callback()
     {
         printf(
-            '<input type="text" id="b2c_admin_policy_id" name="b2c_config_elements[b2c_admin_policy_id]" value="%s" />',
+            '<input type="text" id="b2c_admin_policy_id" name="b2c_config_elements[b2c_admin_policy_id]" value="%s" />'
+            . '<br/><i>Can be the same as Sign-in Policy for Users but typically includes multi-factor authentication for extra protection of Wordpress administration mode.</i>',
             isset( $this->options['b2c_admin_policy_id'] ) ? esc_attr( $this->options['b2c_admin_policy_id']) : ''
         );
     }
@@ -199,7 +211,9 @@ class B2C_Settings_Page
     public function b2c_subscriber_policy_id_callback()
     {
         printf(
-            '<input type="text" id="b2c_subscriber_policy_id" name="b2c_config_elements[b2c_subscriber_policy_id]" value="%s" />',
+            '<input type="text" id="b2c_subscriber_policy_id" name="b2c_config_elements[b2c_subscriber_policy_id]" value="%s" />'
+            . '<br/><i>Specify a Sign-in Policy if you manage creation of Wordpress subscriber accounts yourself.</i>'
+            . '<br/><i>Specify a Sign-in/Sign-up policy to allow Wordpress users to create their own subscriber accounts.</i>',
             isset( $this->options['b2c_subscriber_policy_id'] ) ? esc_attr( $this->options['b2c_subscriber_policy_id']) : ''
         );
     }
@@ -212,6 +226,18 @@ class B2C_Settings_Page
         printf(
             '<input type="text" id="b2c_edit_profile_policy_id" name="b2c_config_elements[b2c_edit_profile_policy_id]" value="%s" />',
             isset( $this->options['b2c_edit_profile_policy_id'] ) ? esc_attr( $this->options['b2c_edit_profile_policy_id']) : ''
+        );
+    }
+	
+    /** 
+     * Get the settings option array and print one of its values
+     */
+    public function b2c_password_reset_policy_id_callback()
+    {
+        printf(
+            '<input type="text" id="b2c_password_reset_policy_id" name="b2c_config_elements[b2c_password_reset_policy_id]" value="%s" />'
+            . '<br/><i>Used if your Sign-in Policy for Users is using a sign-in/sign-up policy and the user clicks the forgotten password link.</i>',
+            isset( $this->options['b2c_password_reset_policy_id'] ) ? esc_attr( $this->options['b2c_password_reset_policy_id']) : ''
         );
     }
 	

--- a/class-b2c-settings-page.php
+++ b/class-b2c-settings-page.php
@@ -75,9 +75,17 @@ class B2C_Settings_Page
         );  
 
         add_settings_field(
-            'b2c_aad_tenant', // ID
-            'Tenant Name / Tenant ID', // Title 
-            array( $this, 'b2c_aad_tenant_callback' ), // Callback
+            'b2c_aad_tenant_name', // ID
+            'Tenant Name', // Title 
+            array( $this, 'b2c_aad_tenant_name_callback' ), // Callback
+            'b2c-settings-page', // Page
+            'service_config_section' // Section  
+        );      
+
+        add_settings_field(
+            'b2c_aad_tenant_domain', // ID
+            'Tenant Domain', // Title 
+            array( $this, 'b2c_aad_tenant_domain_callback' ), // Callback
             'b2c-settings-page', // Page
             'service_config_section' // Section  
         );      
@@ -139,9 +147,12 @@ class B2C_Settings_Page
     public function sanitize( $input )
     {
         $new_input = array();
-		if( isset( $input['b2c_aad_tenant'] ) )
-            $new_input['b2c_aad_tenant'] = sanitize_text_field(strtolower( $input['b2c_aad_tenant'] ));
-		
+		if( isset( $input['b2c_aad_tenant_name'] ) )
+            $new_input['b2c_aad_tenant_name'] = sanitize_text_field(strtolower( $input['b2c_aad_tenant_name'] ));
+
+        if( isset( $input['b2c_aad_tenant_domain'] ) )
+            $new_input['b2c_aad_tenant_domain'] = sanitize_text_field(strtolower( $input['b2c_aad_tenant_domain'] ));
+            
         if( isset( $input['b2c_client_id'] ) )
             $new_input['b2c_client_id'] = sanitize_text_field( $input['b2c_client_id'] );
 
@@ -173,12 +184,24 @@ class B2C_Settings_Page
 	/** 
      * Get the settings option array and print one of its values
      */
-    public function b2c_aad_tenant_callback()
+    public function b2c_aad_tenant_name_callback()
     {
         printf(
-            '<input type="text" id="b2c_aad_tenant" name="b2c_config_elements[b2c_aad_tenant]" value="%s" />' 
-            . '<br/><i>i.e. contoso.onmicrosoft.com</i>',
-            isset( $this->options['b2c_aad_tenant'] ) ? esc_attr( $this->options['b2c_aad_tenant']) : ''
+            '<input type="text" id="b2c_aad_tenant_name" name="b2c_config_elements[b2c_aad_tenant_name]" value="%s" />' 
+            . '<br/><i>ex: contoso (used to create metadata endpoint uri like "contoso.b2clogin.com")</i>',
+            isset( $this->options['b2c_aad_tenant_name'] ) ? esc_attr( $this->options['b2c_aad_tenant_name']) : ''
+        );
+    }
+
+	/** 
+     * Get the settings option array and print one of its values
+     */
+    public function b2c_aad_tenant_domain_callback()
+    {
+        printf(
+            '<input type="text" id="b2c_aad_tenant_domain" name="b2c_config_elements[b2c_aad_tenant_domain]" value="%s" />' 
+            . '<br/><i>ex: contoso.onmicrosoft.com</i>',
+            isset( $this->options['b2c_aad_tenant_domain'] ) ? esc_attr( $this->options['b2c_aad_tenant_domain']) : ''
         );
     }
 

--- a/class-b2c-settings.php
+++ b/class-b2c-settings.php
@@ -3,7 +3,8 @@
 class B2C_Settings {
 	
 	// These settings are configurable by the admin
-	public static $tenant = "";
+	public static $tenant_name = ""; // ex: contoso
+	public static $tenant_domain = ""; // ex: contoso.onmicrosoft.com
 	public static $clientID = "";
 	public static $generic_policy = "";
 	public static $admin_policy = "";
@@ -26,7 +27,8 @@ class B2C_Settings {
 		if (isset($config_elements)) {
 		
 			// Parse the settings entered in by the admin on the b2c settings page
-			self::$tenant = $config_elements['b2c_aad_tenant'];
+			self::$tenant_name = $config_elements['b2c_aad_tenant_name'];
+			self::$tenant_domain = $config_elements['b2c_aad_tenant_domain'];
 			self::$clientID = $config_elements['b2c_client_id'];
 			self::$generic_policy = $config_elements['b2c_subscriber_policy_id'];
 			self::$admin_policy = $config_elements['b2c_admin_policy_id'];
@@ -39,9 +41,7 @@ class B2C_Settings {
 	}
 
 	static function metadata_endpoint_begin() {
-		return 'https://login.microsoftonline.com/'.
-				self::$tenant.
-				'/v2.0/.well-known/openid-configuration?p=';
+		return 'https://'.self::$tenant_name.'.b2clogin.com/'.self::$tenant_domain.'/v2.0/.well-known/openid-configuration?p=';
 	}
 }
 

--- a/class-b2c-settings.php
+++ b/class-b2c-settings.php
@@ -8,6 +8,7 @@ class B2C_Settings {
 	public static $generic_policy = "";
 	public static $admin_policy = "";
 	public static $edit_profile_policy = "";
+	public static $password_reset_policy = "";
 	public static $redirect_uri = "";
 	public static $verify_tokens = 1;
 	
@@ -30,6 +31,7 @@ class B2C_Settings {
 			self::$generic_policy = $config_elements['b2c_subscriber_policy_id'];
 			self::$admin_policy = $config_elements['b2c_admin_policy_id'];
 			self::$edit_profile_policy = $config_elements['b2c_edit_profile_policy_id'];
+			self::$password_reset_policy = $config_elements['b2c_password_reset_policy_id'];
 			self::$redirect_uri = urlencode(site_url().'/'); 
 			if ($config_elements['b2c_verify_tokens']) self::$verify_tokens = 1;
 			else self::$verify_tokens = 0;


### PR DESCRIPTION
Ignore auth error when user cancels profile edit or sign-up flow.
Handle password reset request on sign-in/sign-up flow.
Handle Wordpress password reset request.
Use b2clogin.com instead of login.microsoftonline.com.
Added instructions to Wordpress settings page.