### PR TITLE
Fix error with $decoded_response being an uncountable type

### DIFF
--- a/class-b2c-endpoint-handler.php
+++ b/class-b2c-endpoint-handler.php
@@ -12,7 +12,7 @@ class B2C_Endpoint_Handler {
 		$this->metadata_endpoint = B2C_Settings::metadata_endpoint_begin() . $policy_name;
 		$response = wp_remote_get($this->metadata_endpoint);
 		$decoded_response = json_decode($response['body'], true);
-		if (count($decoded_response) == 0 )
+		if (isset($decoded_response) || empty($decoded_response))
 			throw new Exception('Unable to retrieve metadata from ' . $this->metadata_endpoint);
 		
 		$this->metadata = $decoded_response;

--- a/class-b2c-endpoint-handler.php
+++ b/class-b2c-endpoint-handler.php
@@ -12,7 +12,7 @@ class B2C_Endpoint_Handler {
 		$this->metadata_endpoint = B2C_Settings::metadata_endpoint_begin() . $policy_name;
 		$response = wp_remote_get($this->metadata_endpoint);
 		$decoded_response = json_decode($response['body'], true);
-		if (isset($decoded_response) || empty($decoded_response))
+		if (empty($decoded_response) || !isset($decoded_response) )
 			throw new Exception('Unable to retrieve metadata from ' . $this->metadata_endpoint);
 		
 		$this->metadata = $decoded_response;


### PR DESCRIPTION
```
$decoded_response = json_decode($response['body'], true);
```

Can return NULL. The following line tries to count a type (NULL) which isn't a countable type which in turn produces a warning message. 

The proposed fix solves this. 